### PR TITLE
[Technical-Support] LPS-69873 match with JournalArticleTag property set.

### DIFF
--- a/journal-taglib/src/main/resources/META-INF/liferay-journal.tld
+++ b/journal-taglib/src/main/resources/META-INF/liferay-journal.tld
@@ -15,6 +15,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>ddmTemplateKey</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>groupId</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -30,11 +35,6 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 			<type>boolean</type>
-		</attribute>
-		<attribute>
-			<name>templateKey</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 	</tag>
 </taglib>


### PR DESCRIPTION
Hi Eudaldo,

The root issue is that tld defined property can't match JournalArticleTag set method.

Could you please help review it?

Regards,
Hai