### PR TITLE
LPS-72509 Do not allow updates to Permissions while editing Journal c…

### DIFF
--- a/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
+++ b/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
@@ -39,10 +39,7 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	immediate = true,
-	property = {
-		"javax.portlet.name=" + JournalPortletKeys.JOURNAL,
-		"path=/edit_article.jsp"
-	},
+	property = {"javax.portlet.name=" + JournalPortletKeys.JOURNAL},
 	service = PortletConfigurationIcon.class
 )
 public class PermissionsPortletConfigurationIcon


### PR DESCRIPTION
/cc @Alec-Shay

Hi Eudaldo

I am sending you this because Jonathan Mccann is out of the office.

Notes from Alec:
> Relevant tickets:
> 
> https://issues.liferay.com/browse/LPP-25469
> https://issues.liferay.com/browse/LPS-72509
> 
> If the Permissions for a Web Content article are edited in the edit form (using the menu shown in the attached screenshot), the user cannot publish changes to the article itself unless the form is refreshed. This is due to an old validation check for concurrent updates added with [LPS-15308](https://issues.liferay.com/browse/LPS-15308).
> 
> Previously, I had tried fixing this by removing the validation check, as it appeared to be redundant; you can see a more thorough explanation of the check itself in my original notes [here](https://github.com/SamZiemer/com-liferay-journal/pull/10#issue-227831721), and [here](https://github.com/liferay/com-liferay-journal/pull/313#issuecomment-301832114).
> 
> However, based on [this comment on the previous pull request](https://github.com/liferay/com-liferay-journal/pull/313#issuecomment-302329990), the correct fix should be not to allow users to modify the permissions while in the middle of updating an article's content itself. The journal-web module's `PermissionsPortletConfigurationIcon` class is what adds this option to the edit form's menu in the corner, so this change should avoid the issue while being safer for regressions.